### PR TITLE
Fix text partially being cut off right after "Status:"

### DIFF
--- a/lib/modules/Toolbox-GUI.psm1
+++ b/lib/modules/Toolbox-GUI.psm1
@@ -126,7 +126,7 @@ $main_form.Controls.Add($Label2)
 # Label to display Status
 $Label3 = New-Object System.Windows.Forms.Label
 $Label3.Text = ""
-$Label3.Location  = New-Object System.Drawing.Point(40,262)
+$Label3.Location  = New-Object System.Drawing.Point(50,262)
 $Label3.AutoSize = $true
 $main_form.Controls.Add($Label3)
 


### PR DESCRIPTION
Before:
<img width="729" height="407" alt="grafik" src="https://github.com/user-attachments/assets/02f94154-1248-42e3-b8b2-8a9fc90d04c7" />

After:
<img width="728" height="382" alt="grafik" src="https://github.com/user-attachments/assets/a10b6f38-950a-4e7c-9810-ce9a7400a81e" />


Signed-off-by: ThiloteE <73715071+ThiloteE@users.noreply.github.com>